### PR TITLE
Handle renditions that are not ready

### DIFF
--- a/src/FotowebClient.php
+++ b/src/FotowebClient.php
@@ -281,7 +281,7 @@ class FotowebClient extends GuzzleClient
         while ($retries < $max_retries) {
             $response = $this->getHttpClient()->get($href); 
             if ($response->getStatusCode() === 200) {
-                return $response;
+                return $response;
             }
             $retries++;
             sleep(1);

--- a/src/FotowebClient.php
+++ b/src/FotowebClient.php
@@ -275,8 +275,17 @@ class FotowebClient extends GuzzleClient
      *
      * @return mixed
      */
-    public function getRendition($href)
+    public function getRendition($href, int $max_retries = 10)
     {
-        return $this->getHttpClient()->get($href);
+        $retries = 0;
+        while ($retries < $max_retries) {
+            $response = $this->getHttpClient()->get($href); 
+            if ($response->getStatusCode() === 200) {
+                return $response;
+            }
+            $retries++;
+            sleep(1);
+        }
+        return $response;
     }
 }


### PR DESCRIPTION
According to the documentation: https://learn.fotoware.com/Integrations_and_APIs/001_The_FotoWare_API/FotoWare_API_Overview/Downloading_asset_renditions_using_the_RESTful_API

The response of a request to download a rendition can either return status code 200 or 202.

If the status code is 202:

> "the rendition is not ready yet, and the client should retry the request after a short delay."

This PR adds some crude logic to make that possible, since getting a 202 seems to be quite common. And we should wait for it to be ready, in those cases